### PR TITLE
Document expected format for times, see #1

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -75,6 +75,9 @@ enum Command {
         id: Option<String>,
     },
     /// Lists meter readings.
+    /// Times are expressed either in ISO-8601 format (e.g. 2023-11-01T00:00:00Z) or as a
+    /// negative offset from the current time in minutes, so `-1440` would be
+    /// interpreted as 24 hours ago.
     Readings {
         /// The resource to read.
         resource_id: String,
@@ -84,6 +87,9 @@ enum Command {
         to: Option<String>,
     },
     /// Retrieves device data in InfluxDB line protocol.
+    /// Times are expressed either in ISO-8601 format (e.g. 2023-11-01T00:00:00Z) or as a
+    /// negative offset from the current time in minutes, so `-1440` would be
+    /// interpreted as 24 hours ago.
     Influx {
         /// The device to read. If absent all devices are read.
         #[clap(short, long, env)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,6 +75,7 @@ enum Command {
         id: Option<String>,
     },
     /// Lists meter readings.
+    ///
     /// Times are expressed either in ISO-8601 format (e.g. 2023-11-01T00:00:00Z) or as a
     /// negative offset from the current time in minutes, so `-1440` would be
     /// interpreted as 24 hours ago.
@@ -87,6 +88,7 @@ enum Command {
         to: Option<String>,
     },
     /// Retrieves device data in InfluxDB line protocol.
+    ///
     /// Times are expressed either in ISO-8601 format (e.g. 2023-11-01T00:00:00Z) or as a
     /// negative offset from the current time in minutes, so `-1440` would be
     /// interpreted as 24 hours ago.


### PR DESCRIPTION
Adds a description of the expected format for time values for the influx and readings commands.

Have identified where the parsing is done but am not yet proficient enough in Rust to improve the handling of the error message.